### PR TITLE
add --log-format for JSON output (stackdriver) and --log-to-file bool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/arpitbbhayani/tripod v0.0.0-20170425181942-66807adce3a5
 	github.com/auth0/go-jwt-middleware v0.0.0-20190805220309-36081240882b
+	github.com/blendle/zapdriver v1.3.1
 	github.com/blevesearch/bleve v0.8.0
 	github.com/coreos/bbolt v1.3.2
 	github.com/davecgh/go-spew v1.1.1

--- a/launcher/cli/logging.go
+++ b/launcher/cli/logging.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/blendle/zapdriver"
 	_ "github.com/dfuse-io/dfuse-eosio/kvdb-loader"
 	"github.com/dfuse-io/dfuse-eosio/launcher"
 	zapbox "github.com/dfuse-io/dfuse-eosio/zap-box"
@@ -59,20 +60,25 @@ func init() {
 func setupLogger() {
 	dataDir := viper.GetString("global-data-dir")
 	verbosity := viper.GetInt("global-verbose")
+	logformat := viper.GetString("global-log-format")
+	logToFile := viper.GetBool("global-log-to-file")
 
 	// TODO: The logger expect that the dataDir already exists...
-	// The second argument is a `closer` method, it should be linked to exit of application, for now, we don't care, OS will cleanup
-	logFileWriter := createLogFileWriter(dataDir)
+
+	var logFileWriter zapcore.WriteSyncer
+	if logToFile {
+		logFileWriter = createLogFileWriter(dataDir)
+	}
 	logStdoutWriter := zapcore.Lock(os.Stdout)
 
-	commonLogger := createLogger("common", commongLoggingDef, verbosity, logFileWriter, logStdoutWriter)
+	commonLogger := createLogger("common", commongLoggingDef, verbosity, logFileWriter, logStdoutWriter, logformat)
 	logging.Set(commonLogger)
 
 	for _, appDef := range launcher.AppRegistry {
-		logging.Set(createLogger(appDef.ID, appDef.Logger, verbosity, logFileWriter, logStdoutWriter), appDef.Logger.Regex)
+		logging.Set(createLogger(appDef.ID, appDef.Logger, verbosity, logFileWriter, logStdoutWriter, logformat), appDef.Logger.Regex)
 	}
-	logging.Set(createLogger("dfuse", dfuseLoggingDef, verbosity, logFileWriter, logStdoutWriter), dfuseLoggingDef.Regex)
-	logging.Set(createLogger("bstream", bstreamLoggingDef, verbosity, logFileWriter, logStdoutWriter), bstreamLoggingDef.Regex)
+	logging.Set(createLogger("dfuse", dfuseLoggingDef, verbosity, logFileWriter, logStdoutWriter, logformat), dfuseLoggingDef.Regex)
+	logging.Set(createLogger("bstream", bstreamLoggingDef, verbosity, logFileWriter, logStdoutWriter, logformat), bstreamLoggingDef.Regex)
 
 	// Fine-grain customization
 	//
@@ -102,19 +108,30 @@ func setupLogger() {
 var appToAtomicLevel = map[string]zap.AtomicLevel{}
 var appToAtomicLevelLock sync.Mutex
 
-func createLogger(appID string, loggingDef *launcher.LoggingDef, verbosity int, fileSyncer zapcore.WriteSyncer, consoleSyncer zapcore.WriteSyncer) *zap.Logger {
-	fileCore := zapcore.NewNopCore()
-	if fileSyncer != nil {
-		encoderConfig := zap.NewProductionEncoderConfig()
-		fileCore = zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), fileSyncer, zap.InfoLevel)
-	}
+func createLogger(appID string, loggingDef *launcher.LoggingDef, verbosity int, fileSyncer zapcore.WriteSyncer, consoleSyncer zapcore.WriteSyncer, format string) *zap.Logger {
 
 	// It's ok for concurrent use here, we assume all logger are created in a single goroutine
 	appToAtomicLevel[appID] = zap.NewAtomicLevelAt(appLoggerLevel(loggingDef.Levels, verbosity))
-	consoleCore := zapcore.NewCore(zapbox.NewEncoder(verbosity), consoleSyncer, appToAtomicLevel[appID])
+
+	var consoleCore zapcore.Core
+	switch format {
+	case "json":
+		encoderConfig := zapdriver.NewProductionEncoderConfig()
+		consoleCore = zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), consoleSyncer, appToAtomicLevel[appID])
+	default:
+		consoleCore = zapcore.NewCore(zapbox.NewEncoder(verbosity), consoleSyncer, appToAtomicLevel[appID])
+	}
+
+	if fileSyncer == nil {
+		return zap.New(consoleCore, zap.AddCaller()).Named(appID)
+	}
+
+	encoderConfig := zap.NewProductionEncoderConfig()
+	fileCore := zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), fileSyncer, zap.InfoLevel)
 	teeCore := zapcore.NewTee(consoleCore, fileCore)
 
 	return zap.New(teeCore, zap.AddCaller()).Named(appID)
+
 }
 
 func changeLoggersLevel(inputs string, level zapcore.Level) {

--- a/launcher/cli/main.go
+++ b/launcher/cli/main.go
@@ -41,6 +41,8 @@ func Main() {
 	RootCmd.PersistentFlags().StringP("data-dir", "d", "./dfuse-data", "Path to data storage for all components of dfuse")
 	RootCmd.PersistentFlags().StringP("config-file", "c", "./dfuse.yaml", "dfuse configuration file to use")
 	RootCmd.PersistentFlags().String("nodeos-path", "nodeos", "Path to the nodeos binary. Defaults to the nodeos found in your PATH")
+	RootCmd.PersistentFlags().String("log-format", "text", "Format for logging to stdout. Either 'text' or 'json' (compatible with stackdriver)")
+	RootCmd.PersistentFlags().Bool("log-to-file", true, "Also write logs to {data-dir}/dfuse.log.json ")
 	RootCmd.PersistentFlags().CountP("verbose", "v", "Enables verbose output (-vvvv for max verbosity)")
 
 	derr.Check("registering application flags", core.RegisterFlags(startCmd))


### PR DESCRIPTION
* JSON output is for stackdriver integration
* it respects the requested log level set with `-v`
* log-to-file is to prevent useless write to disk in production