### PR TITLE
Feature/ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ dashboard/client/.npmrc
 /bootstrapping/output.log
 /dfuse.yaml
 /dfuse-data
-#rice-box.go temporarily disable this, ideally we would not commit the rice-box... but until we have a better solution
+/eosq/app/eosq/rice-box.go
 /dist
 *SOURCE_ME.sh*
 dfuseeos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 * [Breaking] `--mindreader-working-dir` default value is now `{dfuse-data-dir}/mindreader/work` instead of `{dfuse-data-dir}/mindreader` this is to prevent mindreader from walking files into the working dir and trying to upload and delete nodes system files like `fork_db.dat`
 * Added `--eosq-environment` environment where eosq will run (local, dev, production)
+* Added `--apiproxy-autocert-domains`, `--apiproxy-autocert-cache-dir` and `--apiproxy-https-listen-addr` to serve SSL directly from proxy.
 
 ### Removed
 
@@ -13,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fixed behavior of `--eosq-api-endpoint-url` to allow specifying protocol (ex: https://api.mydomain.com)
 * The `kvdb-loader` application was renamed `trxdb-loader`. In general what was (confusingly) named `kvdb` is now `trxdb`, so that `kvdb` can now take on its full meaning of a lean key-value storage abstraction (which is also used by FluxDB).
    * All `--kvdb-loader` flags have been renamed to `--trxdb-loader`.
    * Metrics ID for `kvdb-loader` has been changed to `trxdb-loader` (check your dashboards)

--- a/apiproxy/app.go
+++ b/apiproxy/app.go
@@ -15,6 +15,8 @@
 package apiproxy
 
 import (
+	"fmt"
+
 	"github.com/dfuse-io/dfuse-eosio/launcher"
 	"github.com/dfuse-io/shutter"
 )
@@ -36,6 +38,8 @@ import (
 
 type Config struct {
 	HTTPListenAddr   string
+	HTTPSListenAddr  string
+	AutocertDomains  []string
 	DgraphqlHTTPAddr string
 	EoswsHTTPAddr    string
 	NodeosHTTPAddr   string
@@ -56,6 +60,10 @@ func New(config *Config) *App {
 }
 
 func (a *App) Run() error {
+	if a.config.HTTPSListenAddr != "" && len(a.config.AutocertDomains) == 0 {
+		return fmt.Errorf("https listen address is set, but you did not specify autocert domains for SSL")
+	}
+
 	p := newProxy(a.config)
 
 	a.OnTerminating(p.Shutdown)

--- a/apiproxy/app.go
+++ b/apiproxy/app.go
@@ -44,6 +44,7 @@ type Config struct {
 	EoswsHTTPAddr    string
 	NodeosHTTPAddr   string
 	RootHTTPAddr     string
+	AutocertCacheDir string
 }
 
 type App struct {

--- a/apiproxy/proxy.go
+++ b/apiproxy/proxy.go
@@ -72,13 +72,14 @@ func (p *proxy) Launch() error {
 	if p.config.HTTPSListenAddr != "" {
 		zlog.Info("Starting SSL listener", zap.Any("domains", p.config.AutocertDomains))
 		m := &autocert.Manager{
-			Cache:      autocert.DirCache("secret-dir"),
+			Cache:      autocert.DirCache(p.config.AutocertCacheDir),
 			Prompt:     autocert.AcceptTOS,
 			HostPolicy: autocert.HostWhitelist(p.config.AutocertDomains...),
 		}
 		p.httpsServer = &http.Server{
 			Addr:      p.config.HTTPSListenAddr,
 			TLSConfig: m.TLSConfig(),
+			Handler:   router,
 		}
 		go func() {
 			err := p.httpsServer.ListenAndServeTLS("", "")

--- a/apiproxy/proxy.go
+++ b/apiproxy/proxy.go
@@ -9,12 +9,14 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/acme/autocert"
 )
 
 type proxy struct {
 	*shutter.Shutter
 	config        *Config
 	httpServer    *http.Server
+	httpsServer   *http.Server
 	dgraphqlProxy *httputil.ReverseProxy
 	eoswsProxy    *httputil.ReverseProxy
 	nodeosProxy   *httputil.ReverseProxy
@@ -66,6 +68,25 @@ func (p *proxy) Launch() error {
 	}
 
 	zlog.Info("starting http server", zap.String("listen_addr", p.config.HTTPListenAddr))
+
+	if p.config.HTTPSListenAddr != "" {
+		zlog.Info("Starting SSL listener", zap.Any("domains", p.config.AutocertDomains))
+		m := &autocert.Manager{
+			Cache:      autocert.DirCache("secret-dir"),
+			Prompt:     autocert.AcceptTOS,
+			HostPolicy: autocert.HostWhitelist(p.config.AutocertDomains...),
+		}
+		p.httpsServer = &http.Server{
+			Addr:      p.config.HTTPSListenAddr,
+			TLSConfig: m.TLSConfig(),
+		}
+		go func() {
+			err := p.httpsServer.ListenAndServeTLS("", "")
+			if err != nil {
+				p.Shutdown(err)
+			}
+		}()
+	}
 
 	return p.httpServer.ListenAndServe()
 }

--- a/eosq/app/eosq/server_test.go
+++ b/eosq/app/eosq/server_test.go
@@ -1,0 +1,65 @@
+package eosq
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestSanitizeAPIEndpoint(t *testing.T) {
+
+	cases := []struct {
+		name         string
+		in           string
+		expectHost   string
+		expectSecure bool
+	}{
+		{
+			name:         "port only",
+			in:           ":8080",
+			expectHost:   "localhost:8080",
+			expectSecure: false,
+		},
+		{
+			name:         "no protocol",
+			in:           "localhost",
+			expectHost:   "localhost",
+			expectSecure: false,
+		},
+		{
+			name:         "no protocol with port",
+			in:           "localhost:8080",
+			expectHost:   "localhost:8080",
+			expectSecure: false,
+		},
+		{
+			name:         "https with port",
+			in:           "https://my.domain:8443",
+			expectHost:   "my.domain:8443",
+			expectSecure: true,
+		},
+		{
+			name:         "https",
+			in:           "https://my.domain",
+			expectHost:   "my.domain",
+			expectSecure: true,
+		},
+		{
+			name:         "http with sub",
+			in:           "http://my.domain/sub",
+			expectHost:   "my.domain/sub",
+			expectSecure: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			host, secure := sanitizeAPIEndpoint(c.in)
+
+			assert.Equal(t, c.expectHost, host)
+			assert.Equal(t, c.expectSecure, secure)
+
+		})
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	go.opencensus.io v0.22.3
 	go.uber.org/atomic v1.6.0
 	go.uber.org/zap v1.15.0
+	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 	google.golang.org/api v0.15.0
 	google.golang.org/grpc v1.26.0
 	gopkg.in/olivere/elastic.v3 v3.0.75

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/GeertJohan/go.rice v1.0.0
 	github.com/abourget/llerrgroup v0.2.0
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
-	github.com/akavel/rsrc v0.9.0 // indirect
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/arpitbbhayani/tripod v0.0.0-20170425181942-66807adce3a5
@@ -60,12 +59,10 @@ require (
 	github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277
 	github.com/hidal-go/hidalgo v0.0.0-20190814174001-42e03f3b5eaa
 	github.com/improbable-eng/grpc-web v0.12.0
-	github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/manifoldco/promptui v0.7.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/minio/highwayhash v1.0.0
-	github.com/nkovacs/streamquote v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.1.0
 	github.com/prometheus/prom2json v1.3.0
@@ -81,7 +78,6 @@ require (
 	github.com/tidwall/gjson v1.5.0
 	github.com/tidwall/sjson v1.0.4
 	github.com/urfave/negroni v1.0.0 // indirect
-	github.com/valyala/fasttemplate v1.1.0 // indirect
 	go.opencensus.io v0.22.3
 	go.uber.org/atomic v1.6.0
 	go.uber.org/zap v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/akavel/rsrc v0.8.0 h1:zjWn7ukO9Kc5Q62DOJCcxGpXC18RawVtYAGdz2aLlfw=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
-github.com/akavel/rsrc v0.9.0 h1:HwUDC0+tMFWqN4D5G+o5siGD4oVsC3jn6zM8ocjc3nY=
-github.com/akavel/rsrc v0.9.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alecthomas/gometalinter v2.0.11+incompatible/go.mod h1:qfIpQGGz3d+NmgyPBqv+LSh50emm1pt72EtcX2vKYQk=
 github.com/alecthomas/participle v0.2.0 h1:MBYD61je/vgb5ktXrXth/OdH23fn1lNnT5cZLw3fkh8=
 github.com/alecthomas/participle v0.2.0/go.mod h1:SW6HZGeZgSIpcUWX3fXpfZhuaWHnmoD5KCVaqSaNTkk=
@@ -241,8 +239,6 @@ github.com/dfuse-io/graphql-go v0.0.0-20191010213351-ae758277182d/go.mod h1:Au3i
 github.com/dfuse-io/jsonpb v0.0.0-20200406211248-c5cf83f0e0c0 h1:J5o67BQHTqQJsP2krc9770evS3TmkbltKKYMDmq2a3k=
 github.com/dfuse-io/jsonpb v0.0.0-20200406211248-c5cf83f0e0c0/go.mod h1:Qt4EPDfP8T2d/eN96nonFDEyJDMUD3oa/C8LQBX2OAs=
 github.com/dfuse-io/kvdb v0.0.0-20200415145138-10866173305f/go.mod h1:0fof33gPhbtGXKNYHZCYxKBWD+aogZreeWisJ5t5buE=
-github.com/dfuse-io/kvdb v0.0.0-20200424185846-7c443ace0291 h1:f5revq7o9hJAxfO8MtLciWWoVBNh7yNl2bJGD4zWVVY=
-github.com/dfuse-io/kvdb v0.0.0-20200424185846-7c443ace0291/go.mod h1:0fof33gPhbtGXKNYHZCYxKBWD+aogZreeWisJ5t5buE=
 github.com/dfuse-io/kvdb v0.0.0-20200508203924-c107cb0b2fa2 h1:PWOBZnVr5H7qIP/CWPRQ+QqwvyV16o3BuqCooh2t7O0=
 github.com/dfuse-io/kvdb v0.0.0-20200508203924-c107cb0b2fa2/go.mod h1:0fof33gPhbtGXKNYHZCYxKBWD+aogZreeWisJ5t5buE=
 github.com/dfuse-io/logging v0.0.0-20200406213449-45fc25dc6a8d/go.mod h1:80YyilHcgoqrnoIeeJKgcsOw6Y/0/bQzDO/XzNIrIdM=
@@ -505,8 +501,6 @@ github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/compress v1.10.2 h1:Znfn6hXZAHaLPNnlqUYRrBSReFHYybslgv4PTiyz6P0=
 github.com/klauspost/compress v1.10.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
-github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c h1:N7A4JCA2G+j5fuFxCsJqjFU/sZe0mj8H0sSoSwbaikw=
-github.com/koding/websocketproxy v0.0.0-20181220232114-7ed82d81a28c/go.mod h1:Nn5wlyECw3iJrzi0AhIWg+AJUb4PlRQVW4/3XHH1LZA=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -573,8 +567,6 @@ github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJE
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229 h1:E2B8qYyeSgv5MXpmzZXRNp8IAQ4vjxIjhpAf5hv/tAg=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
-github.com/nkovacs/streamquote v1.0.0 h1:PmVIV08Zlx2lZK5fFZlMZ04eHcDTIFJCv/5/0twVUow=
-github.com/nkovacs/streamquote v1.0.0/go.mod h1:BN+NaZ2CmdKqUuTUXUEm9j95B2TRbpOWpxbJYzzgUsc=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -799,8 +791,6 @@ github.com/valyala/fasthttp v1.0.0 h1:BwIoZQbBsTo3v2F5lz5Oy3TlTq4wLKTLV260EVTEWc
 github.com/valyala/fasthttp v1.0.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
 github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8WdUSz8=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
-github.com/valyala/fasttemplate v1.1.0 h1:RZqt0yGBsps8NGvLSGW804QQqCUYYLsaOjTVHy1Ocw4=
-github.com/valyala/fasttemplate v1.1.0/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/dfuse-io/jsonpb v0.0.0-20200406211248-c5cf83f0e0c0/go.mod h1:Qt4EPDfP
 github.com/dfuse-io/kvdb v0.0.0-20200415145138-10866173305f/go.mod h1:0fof33gPhbtGXKNYHZCYxKBWD+aogZreeWisJ5t5buE=
 github.com/dfuse-io/kvdb v0.0.0-20200424185846-7c443ace0291 h1:f5revq7o9hJAxfO8MtLciWWoVBNh7yNl2bJGD4zWVVY=
 github.com/dfuse-io/kvdb v0.0.0-20200424185846-7c443ace0291/go.mod h1:0fof33gPhbtGXKNYHZCYxKBWD+aogZreeWisJ5t5buE=
+github.com/dfuse-io/kvdb v0.0.0-20200508203924-c107cb0b2fa2 h1:PWOBZnVr5H7qIP/CWPRQ+QqwvyV16o3BuqCooh2t7O0=
+github.com/dfuse-io/kvdb v0.0.0-20200508203924-c107cb0b2fa2/go.mod h1:0fof33gPhbtGXKNYHZCYxKBWD+aogZreeWisJ5t5buE=
 github.com/dfuse-io/logging v0.0.0-20200406213449-45fc25dc6a8d/go.mod h1:80YyilHcgoqrnoIeeJKgcsOw6Y/0/bQzDO/XzNIrIdM=
 github.com/dfuse-io/logging v0.0.0-20200407175011-14021b7a79af/go.mod h1:80YyilHcgoqrnoIeeJKgcsOw6Y/0/bQzDO/XzNIrIdM=
 github.com/dfuse-io/logging v0.0.0-20200417143534-5e26069a5e39 h1:vQL3ZKf3mUWvp4hdqCKYJ3J80lshaS/DYE2pB24hWOQ=

--- a/launcher/cli/apps.go
+++ b/launcher/cli/apps.go
@@ -990,7 +990,7 @@ to find how to install it.`)
 			return nil
 		},
 		FactoryFunc: func(modules *launcher.RuntimeModules) (launcher.App, error) {
-			autocertDomains := strings.Split(viper.GetString("apiproxy-https-listen-addr"), ",")
+			autocertDomains := strings.Split(viper.GetString("apiproxy-autocert-domains"), ",")
 			return apiproxy.New(&apiproxy.Config{
 				HTTPListenAddr:   viper.GetString("apiproxy-http-listen-addr"),
 				HTTPSListenAddr:  viper.GetString("apiproxy-https-listen-addr"),

--- a/launcher/cli/apps.go
+++ b/launcher/cli/apps.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	blockmetaApp "github.com/dfuse-io/blockmeta/app/blockmeta"
@@ -979,7 +980,9 @@ to find how to install it.`)
 		MetricsID:   "apiproxy",
 		Logger:      launcher.NewLoggingDef("github.com/dfuse-io/dfuse-eosio/apiproxy.*", nil),
 		RegisterFlags: func(cmd *cobra.Command) error {
-			cmd.Flags().String("apiproxy-http-listen-addr", APIProxyHTTPListenAddr, "TCP Listener addr for gRPC")
+			cmd.Flags().String("apiproxy-http-listen-addr", APIProxyHTTPListenAddr, "HTTP Listener address")
+			cmd.Flags().String("apiproxy-https-listen-addr", "", "If non-empty, will listen for HTTPS connections on this address")
+			cmd.Flags().String("apiproxy-autocert-domains", "", "If non-empty, requests certificates from Let's Encrypt for this comma-separated list of domains")
 			cmd.Flags().String("apiproxy-eosws-http-addr", EoswsHTTPServingAddr, "Target address of the eosws API endpoint")
 			cmd.Flags().String("apiproxy-dgraphql-http-addr", DgraphqlHTTPServingAddr, "Target address of the dgraphql API endpoint")
 			cmd.Flags().String("apiproxy-nodeos-http-addr", NodeosAPIAddr, "Address of a queriable nodeos instance")
@@ -987,8 +990,11 @@ to find how to install it.`)
 			return nil
 		},
 		FactoryFunc: func(modules *launcher.RuntimeModules) (launcher.App, error) {
+			autocertDomains := strings.Split(viper.GetString("apiproxy-https-listen-addr"), ",")
 			return apiproxy.New(&apiproxy.Config{
 				HTTPListenAddr:   viper.GetString("apiproxy-http-listen-addr"),
+				HTTPSListenAddr:  viper.GetString("apiproxy-https-listen-addr"),
+				AutocertDomains:  autocertDomains,
 				EoswsHTTPAddr:    viper.GetString("apiproxy-eosws-http-addr"),
 				DgraphqlHTTPAddr: viper.GetString("apiproxy-dgraphql-http-addr"),
 				NodeosHTTPAddr:   viper.GetString("apiproxy-nodeos-http-addr"),

--- a/launcher/cli/apps.go
+++ b/launcher/cli/apps.go
@@ -983,6 +983,7 @@ to find how to install it.`)
 			cmd.Flags().String("apiproxy-http-listen-addr", APIProxyHTTPListenAddr, "HTTP Listener address")
 			cmd.Flags().String("apiproxy-https-listen-addr", "", "If non-empty, will listen for HTTPS connections on this address")
 			cmd.Flags().String("apiproxy-autocert-domains", "", "If non-empty, requests certificates from Let's Encrypt for this comma-separated list of domains")
+			cmd.Flags().String("apiproxy-autocert-cache-dir", "{dfuse-data-dir}/api-proxy", "Path to directory where certificates will be saved to disk")
 			cmd.Flags().String("apiproxy-eosws-http-addr", EoswsHTTPServingAddr, "Target address of the eosws API endpoint")
 			cmd.Flags().String("apiproxy-dgraphql-http-addr", DgraphqlHTTPServingAddr, "Target address of the dgraphql API endpoint")
 			cmd.Flags().String("apiproxy-nodeos-http-addr", NodeosAPIAddr, "Address of a queriable nodeos instance")
@@ -991,10 +992,15 @@ to find how to install it.`)
 		},
 		FactoryFunc: func(modules *launcher.RuntimeModules) (launcher.App, error) {
 			autocertDomains := strings.Split(viper.GetString("apiproxy-autocert-domains"), ",")
+			dfuseDataDir, err := dfuseAbsoluteDataDir()
+			if err != nil {
+				return nil, err
+			}
 			return apiproxy.New(&apiproxy.Config{
 				HTTPListenAddr:   viper.GetString("apiproxy-http-listen-addr"),
 				HTTPSListenAddr:  viper.GetString("apiproxy-https-listen-addr"),
 				AutocertDomains:  autocertDomains,
+				AutocertCacheDir: mustReplaceDataDir(dfuseDataDir, viper.GetString("apiproxy-autocert-cache-dir")),
 				EoswsHTTPAddr:    viper.GetString("apiproxy-eosws-http-addr"),
 				DgraphqlHTTPAddr: viper.GetString("apiproxy-dgraphql-http-addr"),
 				NodeosHTTPAddr:   viper.GetString("apiproxy-nodeos-http-addr"),


### PR DESCRIPTION
* Added `--apiproxy-autocert-domains`, `--apiproxy-autocert-cache-dir` and `--apiproxy-https-listen-addr` to serve SSL directly from proxy.
* Fixed behavior of `--eosq-api-endpoint-url` to allow specifying protocol (ex: https://api.mydomain.com)
