### PR TITLE
Feature/flags rework

### DIFF
--- a/launcher/cli/flags.go
+++ b/launcher/cli/flags.go
@@ -15,6 +15,7 @@ func AutoBind(root *cobra.Command, prefix string) {
 	viper.SetEnvKeyReplacer(replacer)
 
 	recurseCommands(root, nil)
+	return
 }
 
 func recurseCommands(root *cobra.Command, segments []string) {
@@ -25,10 +26,12 @@ func recurseCommands(root *cobra.Command, segments []string) {
 
 	root.PersistentFlags().VisitAll(func(f *pflag.Flag) {
 		newVar := segmentPrefix + "global-" + f.Name
+		allFlags[newVar] = true
 		viper.BindPFlag(newVar, f)
 	})
 	root.Flags().VisitAll(func(f *pflag.Flag) {
 		newVar := f.Name
+		allFlags[newVar] = true
 		viper.BindPFlag(newVar, f)
 	})
 

--- a/launcher/cli/init.go
+++ b/launcher/cli/init.go
@@ -17,11 +17,11 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"github.com/dfuse-io/dfuse-eosio/launcher"
 	"io/ioutil"
 	"os"
 	"strings"
 
+	"github.com/dfuse-io/dfuse-eosio/launcher"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -78,9 +78,11 @@ func Init(runProducer bool, configFile string) error {
 	}
 
 	apps := launcher.ParseAppsFromArgs(toRun)
-	conf := &launcher.DfuseConfig{}
-	conf.Start.Args = apps
-	conf.Start.Flags = map[string]string{}
+	conf := make(map[string]*launcher.DfuseCommandConfig)
+	conf["start"] = &launcher.DfuseCommandConfig{
+		Args:  apps,
+		Flags: map[string]string{},
+	}
 
 	var err error
 	if runProducer {

--- a/launcher/cli/start.go
+++ b/launcher/cli/start.go
@@ -49,7 +49,7 @@ func dfuseStartE(cmd *cobra.Command, args []string) (err error) {
 	configFile := viper.GetString("global-config-file")
 	userLog.Printf("Starting dfuse for EOSIO with config file '%s'", configFile)
 
-	err = Start(configFile, dataDir, args)
+	err = Start(dataDir, args)
 	if err != nil {
 		return fmt.Errorf("unable to launch: %w", err)
 	}
@@ -59,16 +59,7 @@ func dfuseStartE(cmd *cobra.Command, args []string) (err error) {
 	return
 }
 
-func Start(configFile string, dataDir string, args []string) (err error) {
-
-	config := &launcher.DfuseConfig{}
-	if configFile != "" {
-		config, err = launcher.ReadConfig(configFile)
-		if err != nil {
-			return fmt.Errorf("Error reading config file. Did you 'dfuseeos init' ?  Error: %w", err)
-		}
-	}
-
+func Start(dataDir string, args []string) (err error) {
 	dataDirAbs, err := filepath.Abs(dataDir)
 	if err != nil {
 		return fmt.Errorf("unable to setup directory structure: %w", err)
@@ -99,12 +90,7 @@ func Start(configFile string, dataDir string, args []string) (err error) {
 
 	apps := launcher.ParseAppsFromArgs(args)
 	if len(args) == 0 {
-		apps = launcher.ParseAppsFromArgs(config.Start.Args)
-	}
-
-	// Set default values for flags in `start`
-	for k, v := range config.Start.Flags {
-		viper.SetDefault(k, v)
+		apps = launcher.ParseAppsFromArgs(launcher.DfuseConfig["start"].Args)
 	}
 
 	if containsApp(apps, "mindreader") {

--- a/launcher/cli/start.go
+++ b/launcher/cli/start.go
@@ -94,7 +94,7 @@ func Start(configFile string, dataDir string, args []string) (err error) {
 		return fmt.Errorf("protocol specific hooks not configured correctly: %w", err)
 	}
 
-	launch := launcher.NewLauncher(config, modules)
+	launch := launcher.NewLauncher(modules)
 	userLog.Debug("launcher created")
 
 	apps := launcher.ParseAppsFromArgs(args)

--- a/launcher/config.go
+++ b/launcher/config.go
@@ -7,11 +7,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type DfuseConfig struct {
-	Start struct {
-		Args  []string          `json:"args"`
-		Flags map[string]string `json:"flags"`
-	} `json:"start"`
+var DfuseConfig map[string]*DfuseCommandConfig
+
+type DfuseCommandConfig struct {
+	Args  []string          `json:"args"`
+	Flags map[string]string `json:"flags"`
 }
 
 // Configuration extracted from the `dfuse.yaml` file. User-driven.
@@ -31,19 +31,19 @@ type BoxConfig struct {
 	Version           string `yaml:"version"` // to determine if you need to dfuseeos init again
 }
 
-// Load reads a YAML config, and returns the raw JSON plus a
-// top-level Config object. Use the raw JSON form to provide to the
+// Load reads a YAML config, and sets the global DfuseConfig variable
+// Use the raw JSON form to provide to the
 // different plugins and apps for them to load their config.
-func ReadConfig(filename string) (conf *DfuseConfig, err error) {
+func LoadConfigFile(filename string) (err error) {
 	yamlBytes, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	err = yaml.Unmarshal(yamlBytes, &conf)
+	err = yaml.Unmarshal(yamlBytes, &DfuseConfig)
 	if err != nil {
-		return nil, fmt.Errorf("reading json: %s", err)
+		return fmt.Errorf("reading json: %s", err)
 	}
 
-	return conf, nil
+	return nil
 }

--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -28,7 +28,6 @@ import (
 type Launcher struct {
 	shutter *shutter.Shutter
 
-	config  *DfuseConfig
 	modules *RuntimeModules
 	apps    map[string]App
 
@@ -40,12 +39,11 @@ type Launcher struct {
 	firstShutdownAppID string
 }
 
-func NewLauncher(config *DfuseConfig, modules *RuntimeModules) *Launcher {
+func NewLauncher(modules *RuntimeModules) *Launcher {
 	l := &Launcher{
 		shutter:   shutter.New(),
 		apps:      make(map[string]App),
 		appStatus: make(map[string]pbdashboard.AppStatus),
-		config:    config,
 		modules:   modules,
 	}
 	// TODO: this is weird should re-think this? Should the launcher be passed in every Factory App func instead?


### PR DESCRIPTION
* parse all flags from dfuse.yaml sooner
* Identify and interpret 'global' flags even without the 'global' prefix (ex: log-to-file) to be consistent with the command-line
* config file now allows sections for arbitrary commands (start, init, etc.) with a map[string]DfuseCommandConfig
* BREAKING: fail on invalid dfuse.yaml flag in current command
* closes #74