### PR TITLE
bump merger, change merger flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ date.
   * `--trxdb-loader-truncation-purge-interval`
 
 ### Removed
+* The `--merger-delete-blocks-before` flag is now removed and is the only behavior for merger. 
 * The `--mindreader-merge-and-store-directly` flag was removed. That behavior is now activated by default when encountering 'old blocks'. Also see new flag mindreader-batch-mode.
 * The `--mindreader-discard-after-stop-num` flag was removed, its implementation was too complex and it had no case where it was really useful.
 * The `--eosq-disable-tokenmeta` flag was removed, token meta is now included, so this flag is now obsolete.
@@ -39,6 +40,7 @@ date.
 ### Changed
 * **Breaking Change** FluxDB has been extracted to a dedicated library (github.com/dfuse-io/fluxdb) with complete re-architecture design.
 * **Breaking Change** FluxDB has been renamed to StateDB and is incompatible with previous written data. See [FluxDB Migration](#fluxdb-to-statedb-migration) section below for more details on how to migrate.
+* Merger now restarts from the last produced bundle based on its state file (merger-seen.gob) if it exists. It will go through all existing remote merged-blocks files to populate its seen-blocks-cache and keep progressing this way, so duplicate one-blocks-files will be deleted, but extraneous ones (forked blocks) will be included further away in the merged-blocks produced by the merger.. Flag renamed: `merger-seen-blocks-file` to `merger-state-file` to reflect this change.
 * Merger now deletes blocks that have been processed and are in his "seenBlocks" cache, so a mindreader restarting from recent snapshot will not clog your one-block-file storage
 * Merger now properly handles storage backend errors when looking for where to start
 * Mindreader now automatically start producing "merged blocks" instead of "one-block-files" the blocks are passed a certain age threshold (based on blocktime) OR if a "blockmeta" service can be reached and validates that the blocks numbers are lower than the Last Irreversible Block (LIB). When those conditions cease to be true - close to HEAD -,  it changes to producing one-block-files again (until restarted)

--- a/cmd/dfuseeos/cli/merger.go
+++ b/cmd/dfuseeos/cli/merger.go
@@ -17,7 +17,7 @@ func init() {
 		MetricsID:   "merger",
 		Logger:      launcher.NewLoggingDef("github.com/dfuse-io/merger.*", nil),
 		RegisterFlags: func(cmd *cobra.Command) error {
-			cmd.Flags().Duration("merger-time-between-store-lookups", 10*time.Second, "delay between source store polling (should be higher for remote storage)")
+			cmd.Flags().Duration("merger-time-between-store-lookups", 5*time.Second, "delay between source store polling (should be higher for remote storage)")
 			cmd.Flags().String("merger-state-file", "{dfuse-data-dir}/merger/merger.seen.gob", "Path to file containing last written block number, as well as a map of all 'seen blocks' in the 'max-fixable-fork' range")
 			cmd.Flags().Bool("merger-batch-mode", false, "Ignores the state file, starts and stop based on flags")
 			cmd.Flags().Uint64("merger-start-block-num", 0, "BATCH MODE: Set the block number where we should start processing")

--- a/cmd/dfuseeos/cli/merger.go
+++ b/cmd/dfuseeos/cli/merger.go
@@ -17,19 +17,17 @@ func init() {
 		MetricsID:   "merger",
 		Logger:      launcher.NewLoggingDef("github.com/dfuse-io/merger.*", nil),
 		RegisterFlags: func(cmd *cobra.Command) error {
-			cmd.Flags().Duration("merger-time-between-store-lookups", 10*time.Second, "delay between polling source store (higher for remote storage)")
+			cmd.Flags().Duration("merger-time-between-store-lookups", 10*time.Second, "delay between source store polling (should be higher for remote storage)")
+			cmd.Flags().String("merger-state-file", "{dfuse-data-dir}/merger/merger.seen.gob", "Path to file containing last written block number, as well as a map of all 'seen blocks' in the 'max-fixable-fork' range")
+			cmd.Flags().Bool("merger-batch-mode", false, "Ignores the state file, starts and stop based on flags")
+			cmd.Flags().Uint64("merger-start-block-num", 0, "BATCH MODE: Set the block number where we should start processing")
+			cmd.Flags().Uint64("merger-stop-block-num", 0, "BATCH MODE: Set the block number where we should stop processing (and stop the process)")
 			cmd.Flags().String("merger-grpc-listen-addr", MergerServingAddr, "Address to listen for incoming gRPC requests")
-			cmd.Flags().Bool("merger-process-live-blocks", true, "Ignore --start-.. and --stop-.. blocks, and process only live blocks")
-			cmd.Flags().Uint64("merger-start-block-num", 0, "FOR REPROCESSING: if >= 0, Set the block number where we should start processing")
-			cmd.Flags().Uint64("merger-stop-block-num", 0, "FOR REPROCESSING: if > 0, Set the block number where we should stop processing (and stop the process)")
-			cmd.Flags().String("merger-progress-filename", "", "FOR REPROCESSING: If non-empty, will update progress in this file and start right there on restart")
-			cmd.Flags().Uint64("merger-minimal-block-num", 0, "FOR LIVE: Set the minimal block number where we should start looking at the destination storage to figure out where to start")
+			cmd.Flags().Uint64("merger-minimal-block-num", 0, "Never process blocks lower than that number")
 			cmd.Flags().Duration("merger-writers-leeway", 10*time.Second, "how long we wait after seeing the upper boundary, to ensure that we get as many blocks as possible in a bundle")
-			cmd.Flags().String("merger-seen-blocks-file", "{dfuse-data-dir}/merger/merger.seen.gob", "file to save to / load from the map of 'seen blocks'")
-			cmd.Flags().Uint64("merger-max-fixable-fork", 10000, "after that number of blocks, a block belonging to another fork will be discarded (DELETED depending on flagDeleteBlocksBefore) instead of being inserted in last bundle")
-			cmd.Flags().Bool("merger-delete-blocks-before", true, "Enable deletion of oneblock files when prior to the currently processed bundle and in 'seenBlocks' list (you should really keep this to True)")
+			cmd.Flags().Uint64("merger-max-fixable-fork", 10000, "Size of the 'seen blocks' cache. Anything one-block-file older than this will be deleted.")
 			cmd.Flags().Int("merger-one-block-deletion-threads", 10, "number of parallel threads used to delete one-block-files (more means more stress on your storage backend)")
-			cmd.Flags().Int("merger-max-one-block-operations-batch-size", 2000, "number of good files to look up from storage before we merge them")
+			cmd.Flags().Int("merger-max-one-block-operations-batch-size", 2000, "max number of 'good' (mergeable) files to look up from storage in one polling operation")
 
 			return nil
 		},
@@ -47,7 +45,7 @@ func init() {
 				return
 			}
 
-			if err = mkdirStorePathIfLocal(mustReplaceDataDir(dfuseDataDir, viper.GetString("merger-seen-blocks-file"))); err != nil {
+			if err = mkdirStorePathIfLocal(mustReplaceDataDir(dfuseDataDir, viper.GetString("merger-state-file"))); err != nil {
 				return
 			}
 
@@ -56,19 +54,18 @@ func init() {
 		FactoryFunc: func(runtime *launcher.Runtime) (launcher.App, error) {
 			dfuseDataDir := runtime.AbsDataDir
 			return mergerApp.New(&mergerApp.Config{
-				StorageMergedBlocksFilesPath:   mustReplaceDataDir(dfuseDataDir, viper.GetString("common-blocks-store-url")),
-				StorageOneBlockFilesPath:       mustReplaceDataDir(dfuseDataDir, viper.GetString("common-oneblock-store-url")),
-				TimeBetweenStoreLookups:        viper.GetDuration("merger-time-between-store-lookups"),
-				GRPCListenAddr:                 viper.GetString("merger-grpc-listen-addr"),
-				Live:                           viper.GetBool("merger-process-live-blocks"),
-				StartBlockNum:                  viper.GetUint64("merger-start-block-num"),
-				StopBlockNum:                   viper.GetUint64("merger-stop-block-num"),
-				ProgressFilename:               viper.GetString("merger-progress-filename"),
+				StorageMergedBlocksFilesPath: mustReplaceDataDir(dfuseDataDir, viper.GetString("common-blocks-store-url")),
+				StorageOneBlockFilesPath:     mustReplaceDataDir(dfuseDataDir, viper.GetString("common-oneblock-store-url")),
+				TimeBetweenStoreLookups:      viper.GetDuration("merger-time-between-store-lookups"),
+				GRPCListenAddr:               viper.GetString("merger-grpc-listen-addr"),
+				BatchMode:                    viper.GetBool("merger-batch-mode"),
+				StartBlockNum:                viper.GetUint64("merger-start-block-num"),
+				StopBlockNum:                 viper.GetUint64("merger-stop-block-num"),
+
 				MinimalBlockNum:                viper.GetUint64("merger-minimal-block-num"),
 				WritersLeewayDuration:          viper.GetDuration("merger-writers-leeway"),
-				SeenBlocksFile:                 mustReplaceDataDir(dfuseDataDir, viper.GetString("merger-seen-blocks-file")),
+				StateFile:                      mustReplaceDataDir(dfuseDataDir, viper.GetString("merger-state-file")),
 				MaxFixableFork:                 viper.GetUint64("merger-max-fixable-fork"),
-				DeleteBlocksBefore:             viper.GetBool("merger-delete-blocks-before"),
 				MaxOneBlockOperationsBatchSize: viper.GetInt("merger-max-one-block-operations-batch-size"),
 				OneBlockDeletionThreads:        viper.GetInt("merger-one-block-deletion-threads"),
 			}), nil

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/dfuse-io/jsonpb v0.0.0-20200629203253-eb615da38083
 	github.com/dfuse-io/kvdb v0.0.2-0.20200807025817-f1b87abdaad6
 	github.com/dfuse-io/logging v0.0.0-20200611143916-aade15324493
-	github.com/dfuse-io/merger v0.0.3-0.20200813193037-208d86e877f9
+	github.com/dfuse-io/merger v0.0.3-0.20200818153519-fc11d47236e2
 	github.com/dfuse-io/node-manager v0.0.2-0.20200813012016-72fd864261d6
 	github.com/dfuse-io/opaque v0.0.0-20200407012705-75c4ca372d71
 	github.com/dfuse-io/pbgo v0.0.6-0.20200729035815-5da1dbc5e2ac

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/dfuse-io/jsonpb v0.0.0-20200629203253-eb615da38083
 	github.com/dfuse-io/kvdb v0.0.2-0.20200807025817-f1b87abdaad6
 	github.com/dfuse-io/logging v0.0.0-20200611143916-aade15324493
-	github.com/dfuse-io/merger v0.0.3-0.20200818153519-fc11d47236e2
+	github.com/dfuse-io/merger v0.0.3-0.20200819165818-6ab286a63ba8
 	github.com/dfuse-io/node-manager v0.0.2-0.20200813012016-72fd864261d6
 	github.com/dfuse-io/opaque v0.0.0-20200407012705-75c4ca372d71
 	github.com/dfuse-io/pbgo v0.0.6-0.20200729035815-5da1dbc5e2ac

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,10 @@ github.com/dfuse-io/merger v0.0.3-0.20200724152216-947b231c83f9 h1:+veYaoTWv7j7i
 github.com/dfuse-io/merger v0.0.3-0.20200724152216-947b231c83f9/go.mod h1:QifZGibE21EChWVuYpu+gX1Ilo6mKI6m3odT6kGJcHE=
 github.com/dfuse-io/merger v0.0.3-0.20200813193037-208d86e877f9 h1:995hOnn4DExxNw9gZQGsmc0tdkoKh0728EdiJ3BDDTw=
 github.com/dfuse-io/merger v0.0.3-0.20200813193037-208d86e877f9/go.mod h1:QifZGibE21EChWVuYpu+gX1Ilo6mKI6m3odT6kGJcHE=
+github.com/dfuse-io/merger v0.0.3-0.20200818152705-1998b47aad85 h1:zEwP9DNr8AHEfiGM85x9kCKLKZ9Y9nFdLw9cXPa5T84=
+github.com/dfuse-io/merger v0.0.3-0.20200818152705-1998b47aad85/go.mod h1:QifZGibE21EChWVuYpu+gX1Ilo6mKI6m3odT6kGJcHE=
+github.com/dfuse-io/merger v0.0.3-0.20200818153519-fc11d47236e2 h1:V0qpnuRkNMcrrEsE8NlbiIQoiSxR+QahmlP4GGENHs4=
+github.com/dfuse-io/merger v0.0.3-0.20200818153519-fc11d47236e2/go.mod h1:QifZGibE21EChWVuYpu+gX1Ilo6mKI6m3odT6kGJcHE=
 github.com/dfuse-io/node-manager v0.0.2-0.20200806114600-c2357a71926d h1:h37jc8EMBYet6dX8n1Mjtt7NjGpP5uYUbZrLvbgD8ls=
 github.com/dfuse-io/node-manager v0.0.2-0.20200806114600-c2357a71926d/go.mod h1:Snh8WGAYzivZVLIvY5lXHeB5InueOH58U4/F+C/u+yM=
 github.com/dfuse-io/node-manager v0.0.2-0.20200813012016-72fd864261d6 h1:RQZU3rSGS1DYmMN4ZiVjY5YNcVlGih5V5iZC4yaMJRI=

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f h1:U5y3Y5UE0w7amNe7Z5G/twsBW0KEalRQXZzf8ufSh9I=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f/go.mod h1:xH/i4TFMt8koVQZ6WFms69WAsDWr2XsYL3Hkl7jkoLE=
-github.com/dfuse-io/blockmeta v0.0.2-0.20200724174723-8b30f0cb651d h1:5tr/rOtheS0Xf1qVTe/21ic40rM5pKQ9tVKlTaVQXnw=
-github.com/dfuse-io/blockmeta v0.0.2-0.20200724174723-8b30f0cb651d/go.mod h1:4L26b3+zMyFs9hAAT5bBy9iMl/7l2DwIpHqP+M0v7Hg=
 github.com/dfuse-io/blockmeta v0.0.2-0.20200818234314-2ad05605ed8d h1:oGqLy07dpybRws1lzZqw74wva/2K+8Xoc39HOqo7Uuc=
 github.com/dfuse-io/blockmeta v0.0.2-0.20200818234314-2ad05605ed8d/go.mod h1:4L26b3+zMyFs9hAAT5bBy9iMl/7l2DwIpHqP+M0v7Hg=
 github.com/dfuse-io/bstream v0.0.2-0.20200714123252-e9115283f55f h1:3sATpfUBNfPxSkdcsA5CT3JXMXoypJdT0zMXrM7JEdI=
@@ -293,16 +291,8 @@ github.com/dfuse-io/logging v0.0.0-20200407175011-14021b7a79af/go.mod h1:80YyilH
 github.com/dfuse-io/logging v0.0.0-20200417143534-5e26069a5e39/go.mod h1:80YyilHcgoqrnoIeeJKgcsOw6Y/0/bQzDO/XzNIrIdM=
 github.com/dfuse-io/logging v0.0.0-20200611143916-aade15324493 h1:rMaoK/SwpP+wVvLtq2cLUF7nnO0N8gE4PLXt0YVtKqU=
 github.com/dfuse-io/logging v0.0.0-20200611143916-aade15324493/go.mod h1:80YyilHcgoqrnoIeeJKgcsOw6Y/0/bQzDO/XzNIrIdM=
-github.com/dfuse-io/merger v0.0.3-0.20200724152216-947b231c83f9 h1:+veYaoTWv7j7i3hl9Q05MWps+fxvzImQKkmx2mnBCVU=
-github.com/dfuse-io/merger v0.0.3-0.20200724152216-947b231c83f9/go.mod h1:QifZGibE21EChWVuYpu+gX1Ilo6mKI6m3odT6kGJcHE=
-github.com/dfuse-io/merger v0.0.3-0.20200813193037-208d86e877f9 h1:995hOnn4DExxNw9gZQGsmc0tdkoKh0728EdiJ3BDDTw=
-github.com/dfuse-io/merger v0.0.3-0.20200813193037-208d86e877f9/go.mod h1:QifZGibE21EChWVuYpu+gX1Ilo6mKI6m3odT6kGJcHE=
-github.com/dfuse-io/merger v0.0.3-0.20200818152705-1998b47aad85 h1:zEwP9DNr8AHEfiGM85x9kCKLKZ9Y9nFdLw9cXPa5T84=
-github.com/dfuse-io/merger v0.0.3-0.20200818152705-1998b47aad85/go.mod h1:QifZGibE21EChWVuYpu+gX1Ilo6mKI6m3odT6kGJcHE=
-github.com/dfuse-io/merger v0.0.3-0.20200818153519-fc11d47236e2 h1:V0qpnuRkNMcrrEsE8NlbiIQoiSxR+QahmlP4GGENHs4=
-github.com/dfuse-io/merger v0.0.3-0.20200818153519-fc11d47236e2/go.mod h1:QifZGibE21EChWVuYpu+gX1Ilo6mKI6m3odT6kGJcHE=
-github.com/dfuse-io/node-manager v0.0.2-0.20200806114600-c2357a71926d h1:h37jc8EMBYet6dX8n1Mjtt7NjGpP5uYUbZrLvbgD8ls=
-github.com/dfuse-io/node-manager v0.0.2-0.20200806114600-c2357a71926d/go.mod h1:Snh8WGAYzivZVLIvY5lXHeB5InueOH58U4/F+C/u+yM=
+github.com/dfuse-io/merger v0.0.3-0.20200819165818-6ab286a63ba8 h1:dMlsChukr5qlp2/f+//cqZpzBYp25p5hDsWgkhkcqfo=
+github.com/dfuse-io/merger v0.0.3-0.20200819165818-6ab286a63ba8/go.mod h1:QifZGibE21EChWVuYpu+gX1Ilo6mKI6m3odT6kGJcHE=
 github.com/dfuse-io/node-manager v0.0.2-0.20200813012016-72fd864261d6 h1:RQZU3rSGS1DYmMN4ZiVjY5YNcVlGih5V5iZC4yaMJRI=
 github.com/dfuse-io/node-manager v0.0.2-0.20200813012016-72fd864261d6/go.mod h1:Snh8WGAYzivZVLIvY5lXHeB5InueOH58U4/F+C/u+yM=
 github.com/dfuse-io/opaque v0.0.0-20200407012705-75c4ca372d71 h1:4sHaW1PpyHN2akafVagucu/t+4RqCJQ3WEuowxhdudk=


### PR DESCRIPTION
to address seen-block-cache woes when mindreader sends merged files in its place. See CHANGELOG for all details
