### PR TITLE
add CEL filtering keyword : trxTop5Actors

### DIFF
--- a/filtering/filter.go
+++ b/filtering/filter.go
@@ -80,11 +80,7 @@ type kv struct {
 type actorMap map[string]int
 
 func (m actorMap) add(actor string) {
-	if elem, ok := m[actor]; ok {
-		elem++
-		return
-	}
-	m[actor] = 1
+	m[actor] = m[actor] + 1
 }
 
 func getHeap(m map[string]int) *KVHeap {

--- a/filtering/filter.go
+++ b/filtering/filter.go
@@ -1,6 +1,7 @@
 package filtering
 
 import (
+	"container/heap"
 	"fmt"
 
 	"github.com/dfuse-io/bstream"
@@ -71,6 +72,69 @@ func (f *BlockFilter) TransformInPlace(blk *bstream.Block) error {
 
 }
 
+type kv struct {
+	Key   string
+	Value int
+}
+
+type actorMap map[string]int
+
+func (m actorMap) add(actor string) {
+	if elem, ok := m[actor]; ok {
+		elem++
+		return
+	}
+	m[actor] = 1
+}
+
+func getHeap(m map[string]int) *KVHeap {
+	h := &KVHeap{}
+	heap.Init(h)
+	for k, v := range m {
+		heap.Push(h, kv{k, v})
+	}
+	return h
+}
+
+type KVHeap []kv
+
+func (h KVHeap) Len() int           { return len(h) }
+func (h KVHeap) Less(i, j int) bool { return h[i].Value > h[j].Value }
+func (h KVHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *KVHeap) Push(x interface{}) {
+	*h = append(*h, x.(kv))
+}
+
+func (h *KVHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func getTop5ActorsForTrx(trx *pbcodec.TransactionTrace) (topActors []string) {
+	var actors actorMap
+	actors = make(map[string]int)
+	for _, action := range trx.ActionTraces {
+		actors.add(action.Receiver)
+		actors.add(action.Account())
+		for _, auth := range action.Action.Authorization {
+			actors.add(auth.Actor)
+		}
+	}
+	kvHeap := getHeap(actors)
+	for i := 0; i < 5; i++ {
+		if kvHeap.Len() == 0 {
+			break
+		}
+		act := kvHeap.Pop()
+		topActors = append(topActors, act.(kv).Key)
+	}
+	return
+}
+
 func (f *BlockFilter) transfromInPlace(block *pbcodec.Block) {
 	block.FilteringApplied = true
 	block.FilteringIncludeFilterExpr = f.IncludeProgram.code
@@ -82,11 +146,20 @@ func (f *BlockFilter) transfromInPlace(block *pbcodec.Block) {
 	filteredExecutedTotalActionCount := uint32(0)
 
 	excludedTransactionIds := map[string]bool{}
+
 	for _, trxTrace := range block.UnfilteredTransactionTraces {
 		trxTraceAddedToFiltered := false
 		trxTraceExcluded := true
+		var trxTop5Actors []string //per transaction
+		getTrxTop5Actors := func() []string {
+			if trxTop5Actors == nil {
+				trxTop5Actors = getTop5ActorsForTrx(trxTrace)
+			}
+			return trxTop5Actors
+		}
+
 		for _, actTrace := range trxTrace.ActionTraces {
-			passes, isSystem := f.shouldProcess(trxTrace, actTrace)
+			passes, isSystem := f.shouldProcess(trxTrace, actTrace, getTrxTop5Actors)
 			if !passes {
 				continue
 			}
@@ -106,8 +179,15 @@ func (f *BlockFilter) transfromInPlace(block *pbcodec.Block) {
 		}
 
 		if trxTrace.FailedDtrxTrace != nil {
+			trxTop5Actors = nil
+			getTrxTop5Actors = func() []string {
+				if trxTop5Actors == nil {
+					trxTop5Actors = getTop5ActorsForTrx(trxTrace.FailedDtrxTrace)
+				}
+				return trxTop5Actors
+			}
 			for _, actTrace := range trxTrace.FailedDtrxTrace.ActionTraces {
-				passes, isSystem := f.shouldProcess(trxTrace.FailedDtrxTrace, actTrace)
+				passes, isSystem := f.shouldProcess(trxTrace.FailedDtrxTrace, actTrace, getTrxTop5Actors)
 				if !passes {
 					continue
 				}
@@ -176,8 +256,8 @@ func (f *BlockFilter) transfromInPlace(block *pbcodec.Block) {
 	block.FilteredImplicitTransactionOps = filteredImplicitTrxOp
 }
 
-func (f *BlockFilter) shouldProcess(trxTrace *pbcodec.TransactionTrace, actTrace *pbcodec.ActionTrace) (pass bool, isSystem bool) {
-	activation := actionTraceActivation{trace: actTrace, trxScheduled: trxTrace.Scheduled, trxActionCount: len(trxTrace.ActionTraces)}
+func (f *BlockFilter) shouldProcess(trxTrace *pbcodec.TransactionTrace, actTrace *pbcodec.ActionTrace, trxTop5ActorsGetter func() []string) (pass bool, isSystem bool) {
+	activation := actionTraceActivation{trace: actTrace, trxScheduled: trxTrace.Scheduled, trxActionCount: len(trxTrace.ActionTraces), trxTop5ActorsGetter: trxTop5ActorsGetter}
 	// If the include program does not match, there is nothing more to do here
 	if !f.IncludeProgram.match(&activation) {
 		if f.SystemActionsIncludeProgram.match(&activation) {

--- a/filtering/filter_test.go
+++ b/filtering/filter_test.go
@@ -132,7 +132,7 @@ func TestBlockFilter(t *testing.T) {
 			filter, err := NewBlockFilter(test.exprs.include, test.exprs.exclude, test.exprs.system)
 			require.NoError(t, err)
 
-			hasPass, isSystem := filter.shouldProcess(test.trace, test.trace.ActionTraces[0])
+			hasPass, isSystem := filter.shouldProcess(test.trace, test.trace.ActionTraces[0], func() []string { return nil })
 
 			if test.expectedPass {
 				assert.True(t, hasPass, "Expected action trace to match filter (%s) but it did not", test.exprs)


### PR DESCRIPTION
* returns a list of strings of the accounts that show up most frequently as either account,receiver or auth in any of the actions in the transaction
* can be used like this:  (trx_action_count > 200 && top5_trx_actors.exists(x, x in ['eosiopowcoin', 'eidosonecoin']))
  to completely exclude "spammy" transactions