### PR TITLE
Fix/race trxdb blkdb

### DIFF
--- a/eosws/transactions.go
+++ b/eosws/transactions.go
@@ -113,8 +113,10 @@ func (ws *WSConn) onGetTransaction(ctx context.Context, msg *wsmsg.GetTransactio
 										pause()
 										continue
 									}
+									srcTx, err = ws.db.GetTransaction(ctx, msg.Data.ID)
+								} else {
+									srcTx, err = ws.db.GetTransactionWithExpectedBlockID(ctx, msg.Data.ID, blk.ID())
 								}
-								srcTx, err = ws.db.GetTransactionWithExpectedBlockID(ctx, msg.Data.ID, blk.ID())
 								if err != nil {
 									zlog.Debug("error getting transaction from DB", zap.String("id", blk.ID()), zap.Error(err))
 									pause()

--- a/eosws/transactions.go
+++ b/eosws/transactions.go
@@ -26,7 +26,12 @@ import (
 	"github.com/dfuse-io/dfuse-eosio/eosws/wsmsg"
 	pbcodec "github.com/dfuse-io/dfuse-eosio/pb/dfuse/eosio/codec/v1"
 	eos "github.com/eoscanada/eos-go"
+	"go.uber.org/zap"
 )
+
+func pause() {
+	time.Sleep(500 * time.Millisecond)
+}
 
 func (ws *WSConn) onGetTransaction(ctx context.Context, msg *wsmsg.GetTransaction) {
 	var srcTx *pbcodec.TransactionLifecycle
@@ -97,21 +102,23 @@ func (ws *WSConn) onGetTransaction(ctx context.Context, msg *wsmsg.GetTransactio
 								ws.EmitErrorReply(ctx, msg, DBTrxAppearanceTimeoutError(ctx, blk.ID(), wantedTrxID))
 								return
 							default:
-								b, err := ws.db.GetBlock(ctx, blk.ID())
-								if err != nil {
-									// FIXME: don't we want to distinguish system failures, and NotFound here?
-									time.Sleep(time.Second)
-									continue
+								if waitForIrreversible {
+									lastDBIrr, err := ws.db.GetLastWrittenIrreversibleBlockRef(ctx)
+									if err != nil {
+										zlog.Debug("error getting last irreversible blockref from DB", zap.String("id", blk.ID()), zap.Error(err))
+										pause()
+										continue
+									}
+									if lastDBIrr.Num() < blk.Num() {
+										pause()
+										continue
+									}
 								}
-
-								if waitForIrreversible && !b.Irreversible {
-									time.Sleep(time.Second)
-									continue
-								}
-
-								srcTx, err = ws.db.GetTransaction(ctx, msg.Data.ID)
+								srcTx, err = ws.db.GetTransactionWithExpectedBlockID(ctx, msg.Data.ID, blk.ID())
 								if err != nil {
-									ws.EmitErrorReply(ctx, msg, derr.Wrap(err, "unable to get transaction, internal error"))
+									zlog.Debug("error getting transaction from DB", zap.String("id", blk.ID()), zap.Error(err))
+									pause()
+									continue
 								} else {
 									tx, err := mdl.ToV1TransactionLifecycle(srcTx)
 									if err != nil {


### PR DESCRIPTION
changed "getBlock" to "getLastWrittenIrreversibleBlockRef"  in case of irreversibility because this call is made to the trxdb (not blkdb).

For non-irreversible, the "event matching blockID" is sufficient, the tiny race possible between two events in same block will be negated as soon as it becomes irreversible

@maoueh pls check!
